### PR TITLE
#13-다양한연관관계매핑

### DIFF
--- a/src/main/java/jpabook/jpashop/domain/Category.java
+++ b/src/main/java/jpabook/jpashop/domain/Category.java
@@ -1,0 +1,83 @@
+package jpabook.jpashop.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+@Entity
+public class Category {
+    @Id @GeneratedValue
+    @Column(name = "CATEGORY_ID")
+    private Long id;
+
+    private String name;
+    @ManyToOne
+    @JoinColumn(name = "PARENT_ID")
+    private Category parent;
+    @OneToMany(mappedBy = "parent")
+    private List<Category> child = new ArrayList<>();
+    // category 내에서 부모와 자식관계를 설정해줄수있다. 부모는 많은 가지수, 자식은 부모의 한개를 가져온다.
+
+    @ManyToMany
+    @JoinTable(name = "CATEGORY_ID",
+        joinColumns = @JoinColumn(name = "CATEGORY_ID"),
+        inverseJoinColumns = @JoinColumn(name = "ITEM_ID")
+    )
+    private List<Item> itemList = new ArrayList<>();
+    // 아이템과 카테고리의 다대다 관계를 설정해준다.
+    // 다대다는 실무에서 쓰이지 않는다.
+    // why?
+    // 관계형데이터베이스에서는 다대다 관계에 중간테이블이 필요한데 객체지향으로 활용하는 jpa의 경우 추가 entity 테이블을 만들지 않아도 가능하여
+    // 다대다 관계를 다대일, 일대다 관계로 승격하여 사용한다.
+
+    public Category() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Category getParent() {
+        return parent;
+    }
+
+    public void setParent(Category parent) {
+        this.parent = parent;
+    }
+
+    public List<Category> getChild() {
+        return child;
+    }
+
+    public void setChild(List<Category> child) {
+        this.child = child;
+    }
+
+    public List<Item> getItemList() {
+        return itemList;
+    }
+
+    public void setItemList(List<Item> itemList) {
+        this.itemList = itemList;
+    }
+}

--- a/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -1,0 +1,74 @@
+package jpabook.jpashop.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+@Entity
+public class Delivery {
+    @Id @GeneratedValue
+    @Column(name = "DELIVERY_ID")
+    private Long id;
+    private String city;
+    private String street;
+    private String zipcode;
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus status;
+    @OneToOne(mappedBy = "delivery")
+    private Order order;
+
+    public Delivery() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getZipcode() {
+        return zipcode;
+    }
+
+    public void setZipcode(String zipcode) {
+        this.zipcode = zipcode;
+    }
+
+    public DeliveryStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(DeliveryStatus status) {
+        this.status = status;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/jpabook/jpashop/domain/DeliveryStatus.java
+++ b/src/main/java/jpabook/jpashop/domain/DeliveryStatus.java
@@ -1,0 +1,4 @@
+package jpabook.jpashop.domain;
+
+public enum DeliveryStatus {
+}

--- a/src/main/java/jpabook/jpashop/domain/Item.java
+++ b/src/main/java/jpabook/jpashop/domain/Item.java
@@ -1,9 +1,12 @@
 package jpabook.jpashop.domain;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 
 @Entity
 public class Item {
@@ -14,7 +17,9 @@ public class Item {
     private String name;
     private int price;
     private int stockQuantity;
-
+    @ManyToMany(mappedBy = "itemList")
+    private List<Category> categoryList = new ArrayList<>();
+    //양방향 매핑을 해주었다.
     public Item() {
 
     }

--- a/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/src/main/java/jpabook/jpashop/domain/Member.java
@@ -23,7 +23,7 @@ public class Member {
     // 왜냐하면 너무 복잡한 설계가 된다.
     // 멤버 객체에는 멤버 관련 필드만 있는게 좋음
     // 실무상 잘못된 코드 (예제니깐 쓰인것임)
-    @OneToMany(mappedBy = "Member")
+    @OneToMany(mappedBy = "member")
     private List<Order> orderList = new ArrayList<>();
 
     public Member() {

--- a/src/main/java/jpabook/jpashop/domain/Order.java
+++ b/src/main/java/jpabook/jpashop/domain/Order.java
@@ -3,6 +3,7 @@ package jpabook.jpashop.domain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -13,6 +14,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
@@ -36,13 +38,32 @@ public class Order {
     // 얘는 비즈니스 적으로 충분히 의미 있는 양방향 설계
     @OneToMany(mappedBy = "order")
     private List<OrderItem> orderItemList = new ArrayList<>();
-
+    @OneToOne
+    @JoinColumn(name = "DELIVERY_ID")
+    private Delivery delivery;
+    // 1 대 1 관계는 다대일, 일대다 관계처럼 fk키가 있는곳에 조인컬럼을 지정을해준다. 연관관계의 주인.
     public Order() {
     }
     // 양방향 관계 편의 메서드
     public void addOrderItemList(OrderItem orderItem){
         orderItemList.add(orderItem);
         orderItem.setOrder(this);
+    }
+
+    public List<OrderItem> getOrderItemList() {
+        return orderItemList;
+    }
+
+    public void setOrderItemList(List<OrderItem> orderItemList) {
+        this.orderItemList = orderItemList;
+    }
+
+    public Delivery getDelivery() {
+        return delivery;
+    }
+
+    public void setDelivery(Delivery delivery) {
+        this.delivery = delivery;
     }
 
     public Long getId() {

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -1,4 +1,4 @@
-package org.etample;
+package org.example;
 
 public class Main {
 


### PR DESCRIPTION
this closes #13 

다대일
가장 많이 쓰이는 연관관계
외래 키는 항상 다쪽(N)에 있다.
고로 양방향의 경우에는 다쪽에 연관관계의 주인을 설정한다.

일대다
일대다의 관계는 엔티티를 1개 이상 참조하여 컬렉션을 이용한다.
일대다의 단방향에서 Team객체가 관리하는 외래 키가 Member에 있다면 
update 할 경우에 쿼리를 두번 실행하기 때문에 다대일의 관계를 설정하여 해결해야한다.
일대다의 양방향은 존재하지않음.

일대일
일대일의 관계는 양쪽이 서로 하나의 관계를 가지는 경우.
외래키가 어느 테이블에 있던 양방향 조회가 가능하다.
Member(주 테이블)  Locker(대상 테이블) 의 관계가 1:1 의 관계에 대표적인 예이다.

다대다
사용안함.
중간테이블 만들어야하여
일대다, 다대일로 승격시켜서 사용